### PR TITLE
Add keyword and tag search finder to AI resource hub

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,793 @@
+:root {
+    --color-bg: #f5f7fb;
+    --color-surface: #ffffff;
+    --color-primary: #2563eb;
+    --color-primary-dark: #1d4ed8;
+    --color-accent: #f97316;
+    --color-muted: #6b7280;
+    --color-border: #e2e8f0;
+    --color-strong: #111827;
+    --shadow-md: 0 12px 30px rgba(15, 23, 42, 0.08);
+    --shadow-sm: 0 6px 20px rgba(15, 23, 42, 0.08);
+    --radius-lg: 20px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--color-bg);
+    color: var(--color-strong);
+}
+
+body {
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+}
+
+mark {
+    background: rgba(37, 99, 235, 0.22);
+    color: var(--color-strong);
+    border-radius: 0.2rem;
+    padding: 0 0.2rem;
+}
+
+.page-wrapper {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+main {
+    flex: 1;
+    width: min(1080px, 92vw);
+    margin: 0 auto;
+    padding-bottom: 6rem;
+}
+
+section {
+    margin-top: 4.5rem;
+}
+
+.section-heading {
+    text-align: left;
+    margin-bottom: 2rem;
+}
+
+.section-heading__eyebrow {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 0.35rem;
+}
+
+.section-heading__lead {
+    color: var(--color-muted);
+    margin-top: 0.75rem;
+    max-width: 52ch;
+}
+
+.hero {
+    background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.15), transparent 55%), var(--color-surface);
+    padding: 4.5rem 0 5rem;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 3rem;
+}
+
+.hero__content {
+    width: min(560px, 88vw);
+}
+
+.hero__eyebrow {
+    color: var(--color-primary);
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    margin-bottom: 0.5rem;
+}
+
+.hero__title {
+    font-size: clamp(2.4rem, 4vw, 3.2rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.hero__lead {
+    margin-top: 1.2rem;
+    font-size: 1.05rem;
+    color: #334155;
+    max-width: 58ch;
+}
+
+.hero__actions {
+    margin-top: 2.4rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.9rem 1.6rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.btn span {
+    display: inline-flex;
+}
+
+.btn--primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-sm);
+}
+
+.btn--primary:hover {
+    background: var(--color-primary-dark);
+    transform: translateY(-2px);
+}
+
+.btn--ghost {
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--color-primary-dark);
+}
+
+.btn--ghost:hover {
+    background: rgba(37, 99, 235, 0.12);
+    transform: translateY(-1px);
+}
+
+.hero__highlight {
+    display: flex;
+    align-items: center;
+}
+
+.hero-card {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(37, 99, 235, 0.03));
+    border-radius: var(--radius-lg);
+    padding: 2.2rem;
+    box-shadow: var(--shadow-md);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    max-width: 320px;
+}
+
+.hero-card__label {
+    color: var(--color-muted);
+    font-size: 0.8rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin-bottom: 0.6rem;
+}
+
+.hero-card__title {
+    margin: 0;
+    font-size: 1.7rem;
+    line-height: 1.2;
+}
+
+.hero-card__text {
+    margin-top: 0.8rem;
+    color: #475569;
+    font-size: 0.98rem;
+}
+
+.quick-access__grid {
+    display: grid;
+    gap: 1.4rem;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
+.quick-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    padding: 1.4rem;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.quick-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.12);
+}
+
+.quick-card__icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--color-primary);
+    font-size: 1.2rem;
+}
+
+.quick-card__title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.quick-card__description {
+    flex: 1;
+    color: var(--color-muted);
+    font-size: 0.92rem;
+}
+
+.quick-card__link {
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--color-primary);
+}
+
+.navigator__panel {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    padding: 2rem;
+    box-shadow: var(--shadow-md);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.navigator__breadcrumbs {
+    font-size: 0.88rem;
+    color: var(--color-muted);
+    margin-bottom: 1.4rem;
+}
+
+.navigator__question h3 {
+    margin: 0 0 1.4rem;
+    font-size: 1.2rem;
+}
+
+.navigator__options {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.navigator-option {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1rem 1.2rem;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(248, 250, 252, 0.9);
+    transition: border-color 0.2s ease, transform 0.2s ease;
+    cursor: pointer;
+}
+
+.navigator-option__label {
+    font-weight: 600;
+}
+
+.navigator-option__description {
+    color: var(--color-muted);
+    font-size: 0.9rem;
+    margin-top: 0.35rem;
+}
+
+.navigator-option:hover {
+    border-color: var(--color-primary);
+    transform: translateY(-2px);
+}
+
+.navigator__result {
+    margin-top: 1.8rem;
+    display: none;
+}
+
+.navigator__result.is-visible {
+    display: block;
+}
+
+.finder {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(37, 99, 235, 0));
+    border-radius: var(--radius-lg);
+    padding: 2.4rem;
+    box-shadow: var(--shadow-md);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.finder__panel {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.finder__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: flex-end;
+}
+
+.finder__label {
+    flex: 1;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.finder__label-text {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+    display: inline-flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.finder__input {
+    width: 100%;
+    padding: 0.85rem 1.1rem;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.finder__input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.finder__clear {
+    display: none;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--color-primary);
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.finder__clear.is-visible {
+    display: inline-flex;
+}
+
+.finder__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.finder__tag {
+    border: none;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    color: #1e293b;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.finder__tag:hover {
+    background: rgba(15, 23, 42, 0.12);
+}
+
+.finder__tag.is-active {
+    background: var(--color-primary);
+    color: #fff;
+}
+
+.finder__tag:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.finder__empty {
+    margin: 0.5rem 0 0;
+    color: var(--color-muted);
+    font-size: 0.92rem;
+}
+
+.finder__empty.is-hidden {
+    display: none;
+}
+
+.finder__results {
+    display: grid;
+    gap: 1rem;
+}
+
+.finder__count {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--color-muted);
+}
+
+.navigator-result__title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.resource-list {
+    display: grid;
+    gap: 1rem;
+}
+
+.resource-item {
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    padding: 1rem 1.1rem;
+    background: #f8fafc;
+}
+
+.resource-item--compact {
+    padding: 0.9rem 1rem;
+    background: var(--color-surface);
+    border-color: rgba(148, 163, 184, 0.35);
+}
+
+.resource-item__title {
+    margin: 0;
+    font-size: 1rem;
+    display: flex;
+    gap: 0.7rem;
+    align-items: center;
+}
+
+.resource-item__title i {
+    color: var(--color-primary);
+}
+
+.resource-item__title-text {
+    font-weight: 600;
+    color: var(--color-strong);
+}
+
+.resource-item__meta {
+    color: var(--color-muted);
+    font-size: 0.86rem;
+    margin-top: 0.4rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.6rem;
+    align-items: center;
+}
+
+.resource-item__type {
+    font-weight: 600;
+    color: var(--color-primary);
+    font-size: 0.82rem;
+}
+
+.resource-item__taglist {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.resource-item__tag {
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--color-primary);
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+
+.resource-item__tag.is-active,
+.resource-item__tag.has-highlight {
+    background: var(--color-primary);
+    color: #fff;
+}
+
+.resource-item__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.8rem;
+    margin-top: 0.8rem;
+}
+
+.resource-item--compact .resource-item__actions {
+    gap: 0.6rem;
+    margin-top: 0.7rem;
+}
+
+.resource-item__link {
+    font-weight: 600;
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.resource-item__path {
+    font-family: 'Inter', monospace;
+    background: rgba(148, 163, 184, 0.16);
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+}
+
+.resource-item--compact .resource-item__description {
+    font-size: 0.88rem;
+}
+
+.directory__grid {
+    display: grid;
+    gap: 1.8rem;
+}
+
+.category-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: var(--shadow-md);
+    padding: 2rem;
+    display: grid;
+    gap: 1.2rem;
+}
+
+.category-card__header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.category-card__icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    background: rgba(37, 99, 235, 0.12);
+    color: var(--color-primary);
+    font-size: 1.3rem;
+}
+
+.category-card__title {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.category-card__description {
+    color: var(--color-muted);
+    margin: 0;
+}
+
+.category-card ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: #475569;
+}
+
+.support {
+    background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 60%);
+    padding: 4rem 0;
+}
+
+.support__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.support-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    padding: 1.6rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: var(--shadow-sm);
+}
+
+.support-card h3 {
+    margin-top: 0;
+}
+
+.support-card ul {
+    margin: 0.8rem 0 0;
+    padding-left: 1.2rem;
+}
+
+.page-footer {
+    margin-top: auto;
+    padding: 2.8rem 1.5rem;
+    background: #0f172a;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.page-footer__content {
+    width: min(1080px, 92vw);
+    margin: 0 auto;
+}
+
+.page-footer__title {
+    font-weight: 600;
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.page-footer__note {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.9rem;
+}
+
+.copy-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.8rem;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--color-primary);
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.82rem;
+    transition: background 0.2s ease;
+}
+
+.copy-btn:hover {
+    background: rgba(37, 99, 235, 0.18);
+}
+
+.copy-btn.is-success {
+    background: rgba(34, 197, 94, 0.18);
+    color: #15803d;
+}
+
+@media (max-width: 960px) {
+    .hero {
+        flex-direction: column;
+        align-items: center;
+        padding: 3.5rem 1.5rem 4rem;
+        gap: 2.5rem;
+    }
+
+    .hero__content {
+        width: 100%;
+    }
+
+    .hero__highlight {
+        width: 100%;
+        justify-content: center;
+    }
+
+    main {
+        width: min(960px, 90vw);
+    }
+}
+
+@media (max-width: 640px) {
+    .hero__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .navigator__panel {
+        padding: 1.6rem;
+    }
+
+    .finder {
+        padding: 1.8rem 1.4rem;
+    }
+
+    .finder__controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .finder__clear.is-visible {
+        align-self: flex-start;
+    }
+
+    .category-card {
+        padding: 1.6rem;
+    }
+}
+.quick-card__title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.quick-card__title .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(37, 99, 235, 0.16);
+    color: var(--color-primary);
+    border-radius: 999px;
+    padding: 0.25rem 0.8rem;
+    font-weight: 700;
+    width: fit-content;
+}
+
+.quick-card .resource-item__actions {
+    margin-top: 0.6rem;
+}
+
+.quick-card .copy-btn {
+    padding: 0.45rem 0.9rem;
+}
+
+.resource-item__description {
+    margin: 0.6rem 0 0;
+    color: #475569;
+    font-size: 0.92rem;
+}
+
+.navigator__breadcrumbs {
+    font-size: 0.88rem;
+    color: var(--color-muted);
+    margin-bottom: 1.4rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.navigator__back-btn {
+    border: none;
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--color-primary);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    cursor: pointer;
+}
+
+.navigator__back-btn:hover {
+    background: rgba(37, 99, 235, 0.18);
+}
+
+.breadcrumbs {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.breadcrumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 500;
+    color: var(--color-muted);
+}
+
+.breadcrumb__separator {
+    color: rgba(148, 163, 184, 0.9);
+    display: inline-flex;
+    align-items: center;
+}
+
+.breadcrumb__separator i {
+    font-size: 0.65rem;
+}
+.quick-card__title-text {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--color-strong);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,540 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const { resourceCatalog, quickLinks, categoryDefinitions, navigatorFlow } = window.ResourceHub;
+    const resourceIndex = new Map(resourceCatalog.map((item) => [item.id, item]));
+
+    const quickLinksContainer = document.getElementById('quick-links');
+    const categoryContainer = document.getElementById('resource-categories');
+    const navigatorQuestionEl = document.getElementById('navigator-question');
+    const navigatorOptionsEl = document.getElementById('navigator-options');
+    const navigatorResultEl = document.getElementById('navigator-result');
+    const navigatorBreadcrumbsEl = document.getElementById('navigator-breadcrumbs');
+    const searchInputEl = document.getElementById('resource-search-input');
+    const searchResultsEl = document.getElementById('resource-search-results');
+    const searchEmptyEl = document.getElementById('resource-search-empty');
+    const searchTagsEl = document.getElementById('resource-search-tags');
+    const searchClearBtn = document.getElementById('resource-search-clear');
+
+    let nodeStack = [navigatorFlow];
+    let trail = [];
+    let showingResult = false;
+    let activeTag = null;
+
+    renderQuickLinks();
+    renderCategories();
+    renderNode(navigatorFlow);
+    initSearch();
+
+    function renderQuickLinks() {
+        quickLinks.forEach((link) => {
+            const resource = resourceIndex.get(link.resourceId);
+            if (!resource) return;
+            const card = document.createElement('article');
+            card.className = 'quick-card';
+
+            const iconWrapper = document.createElement('div');
+            iconWrapper.className = 'quick-card__icon';
+            iconWrapper.innerHTML = `<i class="fa-solid ${link.icon}"></i>`;
+
+            const emphasis = document.createElement('p');
+            emphasis.className = 'quick-card__title';
+            const badge = document.createElement('span');
+            badge.className = 'badge';
+            badge.textContent = link.emphasis;
+            const titleText = document.createElement('span');
+            titleText.className = 'quick-card__title-text';
+            titleText.textContent = resource.title;
+            emphasis.append(badge, titleText);
+
+            const description = document.createElement('p');
+            description.className = 'quick-card__description';
+            description.textContent = link.description;
+
+            const path = document.createElement('div');
+            path.className = 'resource-item__path';
+            path.textContent = resource.drivePath;
+
+            const actions = document.createElement('div');
+            actions.className = 'resource-item__actions';
+            if (resource.url) {
+                const linkEl = document.createElement('a');
+                linkEl.className = 'quick-card__link';
+                linkEl.href = resource.url;
+                linkEl.target = '_blank';
+                linkEl.rel = 'noopener';
+                linkEl.textContent = 'Driveで開く';
+                actions.appendChild(linkEl);
+            }
+            actions.appendChild(createCopyButton(resource.drivePath));
+
+            card.append(iconWrapper, emphasis, description, path, actions);
+            quickLinksContainer.appendChild(card);
+        });
+    }
+
+    function renderCategories() {
+        categoryDefinitions.forEach((category) => {
+            const card = document.createElement('article');
+            card.className = 'category-card';
+
+            const header = document.createElement('div');
+            header.className = 'category-card__header';
+            header.innerHTML = `
+                <div class="category-card__icon"><i class="fa-solid ${category.icon}"></i></div>
+                <div>
+                    <h3 class="category-card__title">${category.title}</h3>
+                    <p class="category-card__description">${category.description}</p>
+                </div>
+            `;
+
+            const list = document.createElement('ul');
+            category.resourceIds.forEach((id) => {
+                const resource = resourceIndex.get(id);
+                if (!resource) return;
+                const item = document.createElement('li');
+                item.innerHTML = `<strong>${resource.title}</strong> — ${resource.description}`;
+                list.appendChild(item);
+            });
+
+            card.append(header, list);
+            categoryContainer.appendChild(card);
+        });
+    }
+
+    function initSearch() {
+        if (!searchInputEl || !searchResultsEl || !searchEmptyEl || !searchTagsEl) {
+            return;
+        }
+
+        const tagSet = new Set();
+        resourceCatalog.forEach((resource) => {
+            (resource.tags || []).forEach((tag) => tagSet.add(tag));
+        });
+
+        Array.from(tagSet)
+            .sort((a, b) => a.localeCompare(b, 'ja'))
+            .forEach((tag) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'finder__tag';
+                button.dataset.tag = tag;
+                button.textContent = `#${tag}`;
+                button.setAttribute('aria-pressed', 'false');
+                button.addEventListener('click', () => {
+                    activeTag = activeTag === tag ? null : tag;
+                    updateTagButtons();
+                    updateSearchResults();
+                });
+                searchTagsEl.appendChild(button);
+            });
+
+        searchInputEl.addEventListener('input', () => {
+            updateSearchResults();
+        });
+
+        if (searchClearBtn) {
+            searchClearBtn.addEventListener('click', () => {
+                if (!searchInputEl.value && !activeTag) return;
+                searchInputEl.value = '';
+                activeTag = null;
+                updateTagButtons();
+                updateSearchResults();
+                searchInputEl.focus();
+            });
+        }
+
+        updateTagButtons();
+        updateSearchResults();
+    }
+
+    function updateSearchResults() {
+        if (!searchInputEl || !searchResultsEl || !searchEmptyEl) {
+            return;
+        }
+
+        const rawQuery = (searchInputEl.value || '').trim();
+        const terms = rawQuery.length ? rawQuery.split(/\s+/).map((word) => word.toLowerCase()) : [];
+        const hasTag = Boolean(activeTag);
+        const hasQuery = terms.length > 0;
+
+        if (!hasQuery && !hasTag) {
+            searchResultsEl.innerHTML = '';
+            searchEmptyEl.textContent = '検索キーワード、またはタグを選択するとおすすめ資料が表示されます。';
+            searchEmptyEl.classList.remove('is-hidden');
+            if (searchClearBtn) {
+                searchClearBtn.classList.remove('is-visible');
+            }
+            return;
+        }
+
+        const results = resourceCatalog.filter((resource) => {
+            if (hasTag && !(resource.tags || []).includes(activeTag)) {
+                return false;
+            }
+            return matchesSearchTerms(resource, terms);
+        });
+
+        searchResultsEl.innerHTML = '';
+        if (!results.length) {
+            searchEmptyEl.textContent = '該当する資料が見つかりませんでした。キーワードやタグを変えてみてください。';
+            searchEmptyEl.classList.remove('is-hidden');
+        } else {
+            searchEmptyEl.classList.add('is-hidden');
+
+            const summary = document.createElement('p');
+            summary.className = 'finder__count';
+            const context = [];
+            if (hasTag) {
+                context.push(`#${activeTag}`);
+            }
+            if (hasQuery) {
+                context.push(`"${rawQuery}"`);
+            }
+            const contextText = context.length ? `（${context.join(' / ')}）` : '';
+            summary.textContent = `${results.length}件ヒットしました${contextText}`;
+            searchResultsEl.appendChild(summary);
+
+            const list = document.createElement('div');
+            list.className = 'resource-list';
+            list.setAttribute('role', 'list');
+
+            results.forEach((resource) => {
+                list.appendChild(
+                    createResourceItem(resource, {
+                        compact: true,
+                        highlightTerms: terms,
+                        emphasizeTag: activeTag
+                    })
+                );
+            });
+
+            searchResultsEl.appendChild(list);
+        }
+
+        if (searchClearBtn) {
+            const shouldShow = hasQuery || hasTag;
+            searchClearBtn.classList.toggle('is-visible', shouldShow);
+        }
+    }
+
+    function updateTagButtons() {
+        if (!searchTagsEl) return;
+        const buttons = searchTagsEl.querySelectorAll('button[data-tag]');
+        buttons.forEach((button) => {
+            const tag = button.dataset.tag;
+            const isActive = activeTag === tag;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    }
+
+    function matchesSearchTerms(resource, terms) {
+        if (!terms.length) return true;
+        const searchable = [
+            resource.title,
+            resource.description,
+            resource.drivePath,
+            resource.type,
+            ...(resource.tags || [])
+        ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase();
+        return terms.every((term) => searchable.includes(term));
+    }
+
+    function renderNode(node) {
+        showingResult = false;
+        navigatorQuestionEl.innerHTML = `<h3>${node.question}</h3>`;
+        navigatorOptionsEl.innerHTML = '';
+        navigatorResultEl.classList.remove('is-visible');
+        navigatorResultEl.innerHTML = '';
+        renderBreadcrumbs();
+
+        node.options.forEach((option) => {
+            const optionEl = document.createElement('button');
+            optionEl.type = 'button';
+            optionEl.className = 'navigator-option';
+            optionEl.setAttribute('role', 'listitem');
+            optionEl.innerHTML = `
+                <span class="navigator-option__label">${option.label}</span>
+                ${option.description ? `<span class="navigator-option__description">${option.description}</span>` : ''}
+            `;
+            optionEl.addEventListener('click', () => handleOption(option));
+            navigatorOptionsEl.appendChild(optionEl);
+        });
+    }
+
+    function handleOption(option) {
+        if (option.next) {
+            nodeStack.push(option.next);
+            trail.push(option.label);
+            renderNode(option.next);
+            return;
+        }
+
+        if (option.resources) {
+            trail.push(option.label);
+            renderResources(option.resources, option.label);
+        }
+    }
+
+    function renderResources(resourceIds, label) {
+        showingResult = true;
+        renderBreadcrumbs();
+
+        navigatorQuestionEl.innerHTML = `
+            <h3>${label} のためにおすすめのリソース</h3>
+            <p>下記のDriveパスをコピーしてアクセスしてください。</p>
+        `;
+        navigatorOptionsEl.innerHTML = '';
+
+        const list = document.createElement('div');
+        list.className = 'resource-list';
+        list.setAttribute('role', 'list');
+        resourceIds.forEach((id) => {
+            const resource = resourceIndex.get(id);
+            if (!resource) return;
+            list.appendChild(createResourceItem(resource));
+        });
+
+        navigatorResultEl.innerHTML = '';
+        navigatorResultEl.appendChild(list);
+        navigatorResultEl.classList.add('is-visible');
+    }
+
+    function renderBreadcrumbs() {
+        navigatorBreadcrumbsEl.innerHTML = '';
+        const wrapper = document.createElement('div');
+        wrapper.className = 'breadcrumbs';
+
+        const backNeeded = showingResult || nodeStack.length > 1;
+        if (backNeeded) {
+            const backBtn = document.createElement('button');
+            backBtn.type = 'button';
+            backBtn.className = 'navigator__back-btn';
+            backBtn.innerHTML = '<i class="fa-solid fa-arrow-left"></i> 戻る';
+            backBtn.addEventListener('click', goBack);
+            navigatorBreadcrumbsEl.appendChild(backBtn);
+        }
+
+        const startCrumb = document.createElement('span');
+        startCrumb.className = 'breadcrumb';
+        startCrumb.textContent = 'スタート';
+        wrapper.appendChild(startCrumb);
+
+        trail.forEach((label) => {
+            const separator = document.createElement('span');
+            separator.className = 'breadcrumb__separator';
+            separator.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+            wrapper.appendChild(separator);
+
+            const crumb = document.createElement('span');
+            crumb.className = 'breadcrumb';
+            crumb.textContent = label;
+            wrapper.appendChild(crumb);
+        });
+
+        navigatorBreadcrumbsEl.appendChild(wrapper);
+    }
+
+    function goBack() {
+        if (showingResult) {
+            showingResult = false;
+            trail.pop();
+            navigatorResultEl.classList.remove('is-visible');
+            navigatorResultEl.innerHTML = '';
+            renderNode(nodeStack[nodeStack.length - 1]);
+            return;
+        }
+
+        if (nodeStack.length > 1) {
+            nodeStack.pop();
+            trail.pop();
+            renderNode(nodeStack[nodeStack.length - 1]);
+        } else {
+            renderNode(nodeStack[0]);
+        }
+    }
+
+    function createResourceItem(resource, options = {}) {
+        const { compact = false, highlightTerms = [], emphasizeTag = null } = options;
+        const normalizedHighlights = Array.from(
+            new Set((highlightTerms || []).map((term) => term.toLowerCase()))
+        );
+
+        const item = document.createElement('article');
+        item.className = 'resource-item';
+        item.setAttribute('role', 'listitem');
+        if (compact) {
+            item.classList.add('resource-item--compact');
+        }
+
+        const title = document.createElement('h4');
+        title.className = 'resource-item__title';
+
+        const icon = document.createElement('i');
+        icon.className = getIconClass(resource.type);
+        title.appendChild(icon);
+
+        const titleText = document.createElement('span');
+        titleText.className = 'resource-item__title-text';
+        titleText.innerHTML = highlightText(resource.title, normalizedHighlights);
+        title.appendChild(titleText);
+
+        const meta = document.createElement('div');
+        meta.className = 'resource-item__meta';
+
+        const typeEl = document.createElement('span');
+        typeEl.className = 'resource-item__type';
+        typeEl.innerHTML = highlightText(resource.type, normalizedHighlights);
+        meta.appendChild(typeEl);
+
+        if (resource.tags && resource.tags.length) {
+            const tagsWrapper = document.createElement('div');
+            tagsWrapper.className = 'resource-item__taglist';
+
+            resource.tags.forEach((tag) => {
+                const tagEl = document.createElement('span');
+                tagEl.className = 'resource-item__tag';
+                tagEl.textContent = tag;
+
+                if (emphasizeTag && tag === emphasizeTag) {
+                    tagEl.classList.add('is-active');
+                }
+
+                if (normalizedHighlights.some((term) => term && tag.toLowerCase().includes(term))) {
+                    tagEl.classList.add('has-highlight');
+                }
+
+                tagsWrapper.appendChild(tagEl);
+            });
+
+            meta.appendChild(tagsWrapper);
+        }
+
+        const description = document.createElement('p');
+        description.className = 'resource-item__description';
+        description.innerHTML = highlightText(resource.description, normalizedHighlights);
+
+        const actions = document.createElement('div');
+        actions.className = 'resource-item__actions';
+
+        if (resource.url) {
+            const link = document.createElement('a');
+            link.className = 'resource-item__link';
+            link.href = resource.url;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.innerHTML = '<i class="fa-solid fa-arrow-up-right-from-square"></i> Driveで開く';
+            actions.appendChild(link);
+        }
+
+        const path = document.createElement('span');
+        path.className = 'resource-item__path';
+        path.innerHTML = highlightText(resource.drivePath, normalizedHighlights);
+        actions.appendChild(path);
+
+        actions.appendChild(createCopyButton(resource.drivePath));
+
+        item.append(title, meta, description, actions);
+        return item;
+    }
+
+    function createCopyButton(text) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'copy-btn';
+        button.innerHTML = '<i class="fa-regular fa-copy"></i> パスをコピー';
+        button.addEventListener('click', async () => {
+            try {
+                await navigator.clipboard.writeText(text);
+                button.classList.add('is-success');
+                button.innerHTML = '<i class="fa-solid fa-check"></i> コピーしました';
+                setTimeout(() => {
+                    button.classList.remove('is-success');
+                    button.innerHTML = '<i class="fa-regular fa-copy"></i> パスをコピー';
+                }, 2000);
+            } catch (error) {
+                button.classList.remove('is-success');
+                button.innerHTML = '<i class="fa-solid fa-triangle-exclamation"></i> コピーできません';
+                setTimeout(() => {
+                    button.innerHTML = '<i class="fa-regular fa-copy"></i> パスをコピー';
+                }, 2000);
+            }
+        });
+        return button;
+    }
+
+    function getIconClass(type) {
+        const normalized = (type || '').toLowerCase();
+        if (normalized.includes('pdf')) return 'fa-regular fa-file-pdf';
+        if (normalized.includes('ppt')) return 'fa-regular fa-file-powerpoint';
+        if (normalized.includes('zip')) return 'fa-regular fa-file-zipper';
+        if (normalized.includes('フォルダ')) return 'fa-regular fa-folder-open';
+        if (normalized.includes('診断')) return 'fa-solid fa-list-check';
+        return 'fa-regular fa-file-lines';
+    }
+
+    function highlightText(text, terms) {
+        const source = text == null ? '' : String(text);
+        const normalizedTerms = Array.from(
+            new Set((terms || []).filter(Boolean).map((term) => term.toLowerCase()))
+        );
+
+        if (!normalizedTerms.length) {
+            return escapeHtml(source);
+        }
+
+        const escapedTerms = normalizedTerms.map(escapeRegExp).filter(Boolean);
+        if (!escapedTerms.length) {
+            return escapeHtml(source);
+        }
+
+        const pattern = `(${escapedTerms.join('|')})`;
+        const regex = new RegExp(pattern, 'gi');
+        const fragments = [];
+        let lastIndex = 0;
+        let match;
+
+        while ((match = regex.exec(source)) !== null) {
+            if (match.index > lastIndex) {
+                fragments.push(escapeHtml(source.slice(lastIndex, match.index)));
+            }
+            fragments.push(`<mark>${escapeHtml(match[0])}</mark>`);
+            lastIndex = regex.lastIndex;
+        }
+
+        if (lastIndex < source.length) {
+            fragments.push(escapeHtml(source.slice(lastIndex)));
+        }
+
+        if (!fragments.length) {
+            return escapeHtml(source);
+        }
+
+        return fragments.join('');
+    }
+
+    function escapeRegExp(str) {
+        return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\$&');
+    }
+
+    function escapeHtml(str) {
+        return String(str).replace(/[&<>"']/g, (char) => {
+            switch (char) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#39;';
+                default:
+                    return char;
+            }
+        });
+    }
+});

--- a/assets/js/resources.js
+++ b/assets/js/resources.js
@@ -1,0 +1,319 @@
+const resourceCatalog = [
+    {
+        id: 'ai-skill-check',
+        title: 'AI習得レベル診断',
+        description: '現在のAI理解度を簡単にチェックできる自己診断フォーム。研修前後のギャップ把握にも。',
+        type: '診断リンク',
+        drivePath: 'Google Drive > 00_Onboarding > AI習得レベル診断（フォーム）',
+        url: '',
+        tags: ['診断', 'スタートガイド']
+    },
+    {
+        id: 'ai-guide',
+        title: 'シード・プランニング AIガイド',
+        description: '社内での生成AI活用に必要な前提知識と全体像をまとめた入門ガイド。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 01_Guides > シード・プランニング AIガイド.pdf',
+        url: '',
+        tags: ['入門', 'ガイド']
+    },
+    {
+        id: 'ai-strategy-playbook',
+        title: 'AIツールプレイブック / AI Strategic Playbook',
+        description: '部署ごとのユースケースや導入ステップを整理したプレイブック。経営・リーダー層向け。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 01_Guides > AIツールプレイブック_AI Strategic Playbook.pdf',
+        url: '',
+        tags: ['戦略', 'リーダー']
+    },
+    {
+        id: 'prompt-collection',
+        title: '考える・アイデア出し・壁打ち専用便利プロンプト集',
+        description: '業務の企画・壁打ちでそのまま使える高品質なプロンプトテンプレート集。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 03_PromptLibrary > 考える・アイデア出し・壁打ち専用便利プロンプト集.pdf',
+        url: '',
+        tags: ['プロンプト', 'テンプレート']
+    },
+    {
+        id: 'prompt-guide',
+        title: 'AIプロンプト上達のコツ | Prompt Guide',
+        description: 'プロンプト改善のポイントやチェックリストをまとめたハンズオンガイド。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 03_PromptLibrary > Prompt Guide.pdf',
+        url: '',
+        tags: ['プロンプト', '改善']
+    },
+    {
+        id: 'prompt-advanced',
+        title: 'AI上級者向けガイド | AI Strategy Advanced',
+        description: 'リーダー層が押さえておきたい高度活用の戦略視点とガバナンスポイント。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 04_Strategy > AI_Strategy_Advanced.pdf',
+        url: '',
+        tags: ['戦略', 'リーダー']
+    },
+    {
+        id: 'ai-intermediate-manual',
+        title: 'AI中級者向けスキルアップと活用マニュアル',
+        description: '現場でAIを使いこなすための実践Tipsと業務フロー事例を収録。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_LearningPaths > AI中級者向けスキルアップと活用マニュアル.pdf',
+        url: '',
+        tags: ['実践', 'マニュアル']
+    },
+    {
+        id: 'ai-operations-manual',
+        title: '生成AI使用運用マニュアル（2025-08-05版）',
+        description: '社内ポリシー・リスク管理・問い合わせフローを明文化した最新版運用マニュアル。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 05_Governance > 生成AI使用運用マニュアル_2025-08-05.pdf',
+        url: '',
+        tags: ['ガバナンス', 'ルール']
+    },
+    {
+        id: 'ai-tools-intro',
+        title: 'AIツール・導入説明（グループリーダー会議 8月7日）',
+        description: 'リーダー会議で使用した導入説明資料。導入プロセスやサポート体制を解説。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 05_Governance > AIツール導入説明_グループリーダー会議_20240807.pdf',
+        url: '',
+        tags: ['導入', 'リーダー']
+    },
+    {
+        id: 'training-folder',
+        title: 'ChatGPT研修資料（Google Drive フォルダ）',
+        description: '各バージョンのChatGPT研修スライド・ハンズオン資料をまとめたフォルダ。',
+        type: 'フォルダ',
+        drivePath: 'Google Drive > 02_Training > ChatGPT研修資料/',
+        url: '',
+        tags: ['研修', 'フォルダ']
+    },
+    {
+        id: 'training-1-0',
+        title: 'ChatGPT 1.0 スタートアップトレーニング (2025/04/03 v2)',
+        description: '基本操作と社内利用例を解説する入門トレーニング資料。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_Training > ChatGPT_1.0_スタートアップトレーニング_20250403_JP v2.pdf',
+        url: '',
+        tags: ['研修', '基礎']
+    },
+    {
+        id: 'training-2-0',
+        title: 'ChatGPT 2.0 メモリー活用トレーニング (2025/04/04)',
+        description: 'メモリ機能を活用した業務効率化のユースケースを紹介。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_Training > ChatGPT_2.0_メモリー活用トレーニング_20250404.pdf',
+        url: '',
+        tags: ['研修', '中級']
+    },
+    {
+        id: 'training-2-2',
+        title: 'ChatGPT 2.2 応用編：精度を上げた活用 (2025/04/09 v2)',
+        description: 'プロンプト評価と改善プロセスにフォーカスした応用トレーニング。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_Training > ChatGPT_2.2_応用編_精度を上げた活用_20250409_JP v2.pdf',
+        url: '',
+        tags: ['研修', '応用']
+    },
+    {
+        id: 'training-3-0',
+        title: 'ChatGPT 3.0 カスタムGPTトレーニング Project Presentation',
+        description: 'カスタムGPTの企画・設計プロセスをハンズオンで学ぶ資料。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_Training > ChatGPT_3.0_カスタムGPTトレーニング_Project Presentation.pdf',
+        url: '',
+        tags: ['研修', 'カスタムGPT']
+    },
+    {
+        id: 'training-4-0',
+        title: 'ChatGPT 4.0 Deep + Research トレーニング',
+        description: 'リサーチワークフローにおける高度検索と分析のコツを解説。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_Training > ChatGPT_4.0_Deep+Researchトレーニング.pdf',
+        url: '',
+        tags: ['研修', 'リサーチ']
+    },
+    {
+        id: 'training-5-0',
+        title: 'CustomGPT 5.0 Training Module：Creating your own GPT',
+        description: '独自GPT構築に必要な要件整理と設定手順をまとめたモジュール。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 02_Training > CustomGPT_5.0_Training_Module_Creating your own GPT.pdf',
+        url: '',
+        tags: ['研修', 'カスタムGPT']
+    },
+    {
+        id: 'training-6-0',
+        title: 'ChatGPT 6.0 エージェントモード活用トレーニング',
+        description: 'エージェントモードでの自動化シナリオを設計するための上級トレーニング。',
+        type: 'PPTX',
+        drivePath: 'Google Drive > 02_Training > ChatGPT_6.0_エージェントモード活用トレーニング.pptx',
+        url: '',
+        tags: ['研修', '上級']
+    },
+    {
+        id: 'b3-case-studies',
+        title: 'B3チームケース紹介資料',
+        description: '現場で成果を上げたユースケースをインタビュー形式で紹介。',
+        type: 'PDF',
+        drivePath: 'Google Drive > 06_Showcase > B3チームケース紹介資料.pdf',
+        url: '',
+        tags: ['事例', '共有']
+    },
+    {
+        id: 'font-pack',
+        title: 'ChatGPTグラフ文字化け対策用日本語フォント',
+        description: 'レポートのグラフ文字化けを防ぐフォントパック。Windows / Mac 両対応。',
+        type: 'ZIP',
+        drivePath: 'Google Drive > 07_Support > ChatGPTグラフ文字化け対策用日本語フォント.zip',
+        url: '',
+        tags: ['サポート', 'フォント']
+    }
+];
+
+const quickLinks = [
+    {
+        resourceId: 'ai-skill-check',
+        icon: 'fa-chart-simple',
+        emphasis: '診断',
+        description: '学習前の現状を数分で自己診断。結果は上長と共有可能。'
+    },
+    {
+        resourceId: 'ai-guide',
+        icon: 'fa-book-open',
+        emphasis: '入門',
+        description: '生成AIの基本と社内ルールをおさらい。まずはここから。'
+    },
+    {
+        resourceId: 'prompt-collection',
+        icon: 'fa-wand-magic-sparkles',
+        emphasis: 'プロンプト',
+        description: 'すぐ使えるテンプレートでアウトプットの質を向上。'
+    },
+    {
+        resourceId: 'training-folder',
+        icon: 'fa-graduation-cap',
+        emphasis: '研修',
+        description: '全研修スライドのフォルダをまとめて開く。'
+    }
+];
+
+const categoryDefinitions = [
+    {
+        id: 'starter',
+        title: 'スタートガイド / ガバナンス',
+        icon: 'fa-compass-drafting',
+        description: '全体像の理解と運用ルールを知りたい方向けの資料。',
+        resourceIds: ['ai-skill-check', 'ai-guide', 'ai-strategy-playbook', 'ai-intermediate-manual', 'ai-operations-manual', 'ai-tools-intro']
+    },
+    {
+        id: 'prompts',
+        title: 'プロンプトテンプレートと実践ノウハウ',
+        icon: 'fa-keyboard',
+        description: '明日から使えるプロンプトテンプレートと改善ガイド。',
+        resourceIds: ['prompt-collection', 'prompt-guide']
+    },
+    {
+        id: 'training',
+        title: 'ChatGPT 研修シリーズ',
+        icon: 'fa-chalkboard-user',
+        description: 'レベル別の研修資料をまとめてチェックできます。',
+        resourceIds: ['training-folder', 'training-1-0', 'training-2-0', 'training-2-2', 'training-3-0', 'training-4-0', 'training-5-0', 'training-6-0']
+    },
+    {
+        id: 'strategy',
+        title: 'リーダー / 戦略視点の資料',
+        icon: 'fa-chess-knight',
+        description: '経営・プロジェクトリード向けの高度活用ガイド。',
+        resourceIds: ['ai-strategy-playbook', 'prompt-advanced', 'training-3-0', 'training-5-0', 'ai-tools-intro']
+    },
+    {
+        id: 'showcase',
+        title: '活用事例・サポートリソース',
+        icon: 'fa-life-ring',
+        description: '成功事例の共有と日常活用を支援するリソース。',
+        resourceIds: ['b3-case-studies', 'font-pack', 'prompt-collection']
+    }
+];
+
+const navigatorFlow = {
+    question: 'まず、目的を教えてください。',
+    options: [
+        {
+            label: '自分のスキルレベルを把握したい',
+            description: '研修前の準備や目標設定のために、現在地を確認したい方向け。',
+            resources: ['ai-skill-check', 'ai-guide']
+        },
+        {
+            label: '研修資料から学びたい',
+            description: 'レベルやテーマ別に ChatGPT 研修資料を探します。',
+            next: {
+                question: 'どの研修テーマに興味がありますか？',
+                options: [
+                    {
+                        label: '基礎〜日常業務で活用したい',
+                        description: 'ChatGPTの基本操作から応用まで段階的に学びたい。',
+                        resources: ['training-1-0', 'training-2-0', 'training-2-2']
+                    },
+                    {
+                        label: 'カスタムGPTや自動化を進めたい',
+                        description: '高度な設計やエージェント活用に踏み込みたい方向け。',
+                        resources: ['training-3-0', 'training-5-0', 'training-6-0']
+                    },
+                    {
+                        label: '調査・分析ワークに活かしたい',
+                        description: 'リサーチの深堀りや資料作成の質向上を目指す。',
+                        resources: ['training-4-0', 'prompt-guide']
+                    },
+                    {
+                        label: 'まとめてフォルダで確認したい',
+                        description: '全研修資料を一括で閲覧したい方向け。',
+                        resources: ['training-folder']
+                    }
+                ]
+            }
+        },
+        {
+            label: 'すぐ使えるプロンプトを知りたい',
+            description: '壁打ちやアイデア出しをスピードアップしたいときに。',
+            resources: ['prompt-collection', 'prompt-guide']
+        },
+        {
+            label: 'チームをリードする立場として整理したい',
+            description: '部署導入やポリシー整備を検討しているリーダー向け。',
+            next: {
+                question: 'どのテーマを重視していますか？',
+                options: [
+                    {
+                        label: '導入・運用ルールを整備したい',
+                        description: 'ガバナンスと社内展開の基礎資料。',
+                        resources: ['ai-operations-manual', 'ai-tools-intro']
+                    },
+                    {
+                        label: '戦略・ユースケースを整理したい',
+                        description: '組織的な活用方針を固めるためのプレイブック。',
+                        resources: ['ai-strategy-playbook', 'prompt-advanced']
+                    },
+                    {
+                        label: '成功事例をチームに共有したい',
+                        description: '他部署の取り組みや効果を紹介。',
+                        resources: ['b3-case-studies']
+                    }
+                ]
+            }
+        },
+        {
+            label: 'トラブル対策やサポート資料を探したい',
+            description: '日常利用で困ったときのヘルプリソース。',
+            resources: ['font-pack', 'prompt-guide', 'ai-intermediate-manual']
+        }
+    ]
+};
+
+window.ResourceHub = {
+    resourceCatalog,
+    quickLinks,
+    categoryDefinitions,
+    navigatorFlow
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>生成AIリソースハブ | シード・プランニング</title>
+    <meta name="description" content="社内の生成AI関連リソースを目的別にナビゲートするポータルサイトです。研修資料やプロンプト集、運用ガイドを素早く見つけられます。">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <div class="page-wrapper">
+        <header class="hero">
+            <div class="hero__content">
+                <p class="hero__eyebrow">Seed Planning | Generative AI Hub</p>
+                <h1 class="hero__title">生成AIリソースハブ</h1>
+                <p class="hero__lead">社内に散らばる生成AIの知見・教材・運用ドキュメントをここに集約。目的を選ぶだけで、今必要な情報に最短でたどり着けます。</p>
+                <div class="hero__actions">
+                    <a class="btn btn--primary" href="#resource-navigator"><i class="fa-solid fa-compass"></i><span>リソースを探す</span></a>
+                    <a class="btn btn--ghost" href="#resource-directory"><i class="fa-solid fa-layer-group"></i><span>一覧を眺める</span></a>
+                </div>
+            </div>
+            <div class="hero__highlight">
+                <div class="hero-card">
+                    <p class="hero-card__label">迷子防止ガイド</p>
+                    <h2 class="hero-card__title">3クリックで適切な資料へ</h2>
+                    <p class="hero-card__text">ナビゲーションウィザードが、スキル診断から研修資料まで順番に案内します。</p>
+                </div>
+            </div>
+        </header>
+
+        <main>
+            <section class="quick-access" aria-labelledby="quick-access-title">
+                <div class="section-heading">
+                    <p class="section-heading__eyebrow">Quick Access</p>
+                    <h2 id="quick-access-title">まずチェックしてほしい定番リソース</h2>
+                    <p class="section-heading__lead">時間がないときは、以下のショートカットからどうぞ。</p>
+                </div>
+                <div class="quick-access__grid" id="quick-links"></div>
+            </section>
+
+            <section class="navigator" id="resource-navigator" aria-labelledby="navigator-title">
+                <div class="section-heading">
+                    <p class="section-heading__eyebrow">Navigator</p>
+                    <h2 id="navigator-title">何をお探しですか？</h2>
+                    <p class="section-heading__lead">質問に答えると、該当するGoogle Drive上の資料パスを提示します。</p>
+                </div>
+                <div class="navigator__panel">
+                    <div class="navigator__breadcrumbs" id="navigator-breadcrumbs" aria-live="polite"></div>
+                    <div class="navigator__question" id="navigator-question"></div>
+                    <div class="navigator__options" id="navigator-options" role="list"></div>
+                    <div class="navigator__result" id="navigator-result"></div>
+                </div>
+            </section>
+
+            <section class="finder" id="resource-search" aria-labelledby="search-title">
+                <div class="section-heading">
+                    <p class="section-heading__eyebrow">Resource Finder</p>
+                    <h2 id="search-title">キーワードやタグで資料を横断検索</h2>
+                    <p class="section-heading__lead">目的がはっきりしている場合は、検索ボックスやタグチップから必要な資料を素早く探せます。</p>
+                </div>
+                <div class="finder__panel">
+                    <div class="finder__controls">
+                        <label class="finder__label" for="resource-search-input">
+                            <span class="finder__label-text"><i class="fa-solid fa-magnifying-glass"></i> キーワードから探す</span>
+                            <input id="resource-search-input" class="finder__input" type="search" placeholder="例：研修 / プロンプト / リーダー">
+                        </label>
+                        <button type="button" id="resource-search-clear" class="finder__clear" aria-label="検索条件をクリア">
+                            <i class="fa-solid fa-rotate-left"></i> クリア
+                        </button>
+                    </div>
+                    <div class="finder__tags" id="resource-search-tags" aria-label="タグで絞り込む"></div>
+                    <p class="finder__empty" id="resource-search-empty">検索キーワード、またはタグを選択するとおすすめ資料が表示されます。</p>
+                    <div class="finder__results" id="resource-search-results" aria-live="polite"></div>
+                </div>
+            </section>
+
+            <section class="directory" id="resource-directory" aria-labelledby="directory-title">
+                <div class="section-heading">
+                    <p class="section-heading__eyebrow">Resource Directory</p>
+                    <h2 id="directory-title">カテゴリ別リソース一覧</h2>
+                    <p class="section-heading__lead">あとから一覧で見直したい場合はこちら。カテゴリごとに内容と目的をまとめています。</p>
+                </div>
+                <div class="directory__grid" id="resource-categories"></div>
+            </section>
+
+            <section class="support" aria-labelledby="support-title">
+                <div class="section-heading">
+                    <p class="section-heading__eyebrow">Workflow Tips</p>
+                    <h2 id="support-title">活用を社内に浸透させるためのヒント</h2>
+                </div>
+                <div class="support__grid">
+                    <article class="support-card">
+                        <h3><i class="fa-solid fa-route"></i> ナビゲーションの使い方</h3>
+                        <p>Google Drive のフォルダ構造と連動させると効果的です。<strong>各リソースの Drive パス</strong>はデータ定義ファイル（<code>assets/js/resources.js</code>）で変更できます。</p>
+                    </article>
+                    <article class="support-card">
+                        <h3><i class="fa-solid fa-users-gear"></i> 共有のベストプラクティス</h3>
+                        <ul>
+                            <li>部署やロール別のおすすめリンクを「クイックアクセス」に設定。</li>
+                            <li>研修完了後に次のステップを案内するフォローアップメールと連携。</li>
+                            <li>Drive のアクセス権が必要な場合は、ナビゲーションの結果に窓口を併記。</li>
+                        </ul>
+                    </article>
+                    <article class="support-card">
+                        <h3><i class="fa-solid fa-pen-to-square"></i> コンテンツ更新の流れ</h3>
+                        <p>新しい資料が追加されたら、<strong>resources.js にタイトル・説明・Drive パスを追記</strong>し、必要に応じてナビゲーションの選択肢にリンクしてください。</p>
+                    </article>
+                </div>
+            </section>
+        </main>
+
+        <footer class="page-footer">
+            <div class="page-footer__content">
+                <p class="page-footer__title">Seed Planning 生成AIラーニングコミッティ</p>
+                <p class="page-footer__note">このページは社内向けのナレッジハブです。リンク先の Google Drive 資料はアクセス権が必要です。</p>
+            </div>
+        </footer>
+    </div>
+
+    <script src="assets/js/resources.js"></script>
+    <script src="assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Resource Finder section with keyword input, tag chips, and clear actions to jump directly to Google Drive assets
- highlight matching text and reuse compact resource cards when showing search results or navigator recommendations
- extend styling with mark highlights, tag badges, and responsive tweaks for the new finder experience

## Testing
- not run (static HTML/CSS/JS site)

------
https://chatgpt.com/codex/tasks/task_b_68cc8fc7ea908331926b0a5822a567bb